### PR TITLE
Update travis badge and add Read the Docs one

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ _|"""""|_|"""""|_|"""""|_|"""""|_|"""""|_|"""""|_|"""""|_|"""""|_|"""""|
 "`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-' 
 ```
 
-[![Build Status](https://api.travis-ci.org/metabrainz/botbot-web.png)](https://travis-ci.org/BotBotMe/botbot-web)
+[![Build Status](https://api.travis-ci.org/metabrainz/brainzbot-core.png)](https://travis-ci.org/Metabrainz/brainzbot-core)
+[![Read the Docs](https://img.shields.io/readthedocs/pip.svg)](https://brainzbot.readthedocs.io/)
 
 Botbot is collection of tools for running IRC bots. It has primarily been
 used with Freenode channels but works with other IRC networks or servers.
@@ -15,4 +16,3 @@ used with Freenode channels but works with other IRC networks or servers.
 This is a fork customized for use by the [MetaBrainz Foundation](https://metabrainz.org).
 It can be seen in action at http://chatlogs.metabrainz.org/
 
-[Documentation](http://botbot.readthedocs.org/en/latest/)


### PR DESCRIPTION
I deleted the other docs link because you click on the badge and get to the docs.